### PR TITLE
Adjusted to API changes in Tiled 2019.10.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 startup.js script for [bjorn/tiled](https://github.com/bjorn/tiled) map editor with export for [Angband.online](http://angband.online) project running on [PWMAngband](http://powerwyrm.monsite-orange.fr/page-56e3134c5ebab.html) base.
 Read the manual to know where you should place the script: https://doc.mapeditor.org/en/latest/reference/scripting/#startup-script
 
-Important: 
-- You should use the latest development snapshot rather than stable version of Tiled (on the moment it is written stable was 1.2.2 and the workig version with API support is 2019.02.10)
+Important:
+- You should use the latest development snapshot rather than stable version of Tiled (on the moment it is written stable was 1.2.4 and the working version with API support is 2019.10.08)
 - Script takes ASCII symbol from custom 'map' field for map section of the export, and from 'mask' field for the mask section. Returns empty space if both fields are empty.

--- a/startup.js
+++ b/startup.js
@@ -1,8 +1,8 @@
 var customMapFormat = {
-    name: 'Andgband.online ASCII',
+    name: 'Angband.online ASCII',
     extension: 'txt',
 
-    toString: function(map, fileName) {
+    write: function(map, fileName) {
 		var layer = map.layerAt(0);
 		var asciiMap = 'feat:grass:tree:0\n\n';
 		var asciiMask = '';
@@ -52,4 +52,4 @@ var customMapFormat = {
     },
 };
 
-tiled.registerMapFormat('Andgband.online', customMapFormat);
+tiled.registerMapFormat('Angband.online', customMapFormat);


### PR DESCRIPTION
'toString' was renamed to 'write' (and can now return either a string or an ArrayBuffer).